### PR TITLE
Update templates.js

### DIFF
--- a/src/setup/templates.js
+++ b/src/setup/templates.js
@@ -14,7 +14,7 @@ const setupTemplates = () => {
     }
     log(`Downloading ${template}`, 'info');
     const { baseBranch, repo } = templates[template];
-    return exec(`git clone ${repo} --branch ${baseBranch} --progress ${template}`);
+    return exec(`git clone ${repo} --branch ${baseBranch} --progress ${templatePath}`);
   });
 };
 


### PR DESCRIPTION
update `template` to `templatePath` in final `exec()` function. As it is, it will create the template in `/repositories/{template}` rather than `/repositories/templates/{template}` which causes the subsequent `nobot template` command to fail (because of a lack of `/repositories/templates`).